### PR TITLE
actual.Should().Be(expected)

### DIFF
--- a/src/Divverence.Akka.TestKit.FluentAssertions/FluentAssertionsAssertions.cs
+++ b/src/Divverence.Akka.TestKit.FluentAssertions/FluentAssertionsAssertions.cs
@@ -53,7 +53,7 @@ namespace Divverence.Akka.TestKit.FluentAssertions
         /// <param name="args">An optional object array that contains zero or more objects to format.</param>
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
         {
-            actual.Should().Be(actual, format, args);
+            actual.Should().Be(expected, format, args);
         }
 
         /// <summary>

--- a/tst/Divverence.Akka.TestKit.FluentAssertions.Tests/FluentAssertionsAssertionsTests.cs
+++ b/tst/Divverence.Akka.TestKit.FluentAssertions.Tests/FluentAssertionsAssertionsTests.cs
@@ -50,6 +50,12 @@ namespace Divverence.Akka.TestKit.FluentAssertions.Tests
         }
 
         [Fact]
+        public void AssetEqualThrowsWhenPassingDifferentObjects() {
+            Action x = () => new FluentAssertionsAssertions().AssertEqual("cat", "dog");
+            x.Should().Throw<Exception>();
+        }
+
+        [Fact]
         public void AssetEqualFancyDoesNotThrowWhenPassingDifferentObjectsButAComparerThatReturnsTrue()
         {
             Action x = () =>


### PR DESCRIPTION
`actual` was being compared against itself, instead of following the method's semantics of comparing it against `expected`